### PR TITLE
Refine landing page visuals and interactivity

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,8 +16,8 @@
        ======================= */
     :root{
       --bg: #0b0b0c;        /* onyx */
-      --ink: #ffffff;       /* white */
-      --muted:#d9d9de;      /* cool gray (brighter) */
+      --ink: #f0f0f3;       /* soft white */
+      --muted:#c7c7cc;      /* cool gray (brighter) */
       --line:#1a1a1d;       /* hairline */
       --card:#111214;       /* deep card */
       --card-2:#0e0f10;     /* deeper card */
@@ -59,6 +59,7 @@
       background: radial-gradient(320px 320px at var(--mx,50%) var(--my,40%), rgba(255,255,255,.15), transparent 70%);
       mix-blend-mode:screen;
       transition: background 120ms linear;
+      display:none;
     }
     /* glow zone text fade */
     .glow-zone :is(h1,h2,h3,h4,p,li,a,span){
@@ -84,15 +85,13 @@
       padding:14px 24px; border-bottom:1px solid var(--line);
       background:rgba(10,10,11,.55); backdrop-filter:saturate(120%) blur(8px);
     }
-    .brand{display:flex; align-items:center; gap:10px; font-weight:900; letter-spacing:.6px}
-    .brand img{width:28px; height:28px; border-radius:6px; filter:drop-shadow(0 4px 16px rgba(0,0,0,.5))}
     .nav-links{display:flex; gap:18px; align-items:center; flex-wrap:wrap; justify-content:center}
-    .nav-links a{padding:8px 14px; border-radius:10px; color:#f5f5f5}
+    .nav-links a{padding:8px 14px; border-radius:10px; color:#e5e5e9}
     .nav-links a:hover{background:#141416}
     .nav-links .cta{border:1px solid var(--line); padding:8px 12px; background:#0f0f11; font-weight:800}
 
     /* ===== Layout container ===== */
-    .wrap{max-width:1200px; margin:0 auto; padding:40px 24px}
+    .wrap{max-width:1200px; margin:0 auto; padding:60px 24px}
 
     /* ===== Hero ===== */
     .hero{
@@ -124,22 +123,22 @@
 
     /* ===== Sections ===== */
     section h2{
-      font-size:24px; letter-spacing:.6px; margin:4px 0 10px; text-transform:uppercase;
+      font-size:24px; letter-spacing:.6px; margin:8px 0 20px; text-transform:uppercase;
       color:#f1f1f1; opacity:.9; text-align:center;
     }
     section p{text-align:center;}
 
     /* ===== Feature cards (tilt + reveal) ===== */
     .cards{
-      display:grid; gap:20px; margin-top:16px;
-      grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+      display:grid; gap:24px; margin-top:16px;
+      grid-template-columns:repeat(3,1fr); grid-auto-rows:1fr;
       justify-items:center;
     }
     .card{
       background:linear-gradient(135deg,var(--card-2),var(--card));
       border:1px solid rgba(255,255,255,.05);
       border-radius:24px;
-      padding:24px;
+      padding:24px; display:flex; flex-direction:column; height:100%;
       transition:transform .3s ease, box-shadow .3s ease, background .3s ease, border-color .3s ease;
       transform-style:preserve-3d; will-change:transform;
     }
@@ -153,12 +152,13 @@
     /* ===== Feature list ===== */
     .feature-list{
       list-style:none; padding:0; margin:10px 0 0;
-      display:grid; gap:10px;
-      grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+      display:grid; gap:20px;
+      grid-template-columns:repeat(3,1fr); grid-auto-rows:1fr;
     }
     .feature-list li{
       border:1px dashed var(--line); border-radius:14px; padding:12px; background:#0f0f11;
-      display:flex; align-items:center; min-height:56px; justify-content:flex-start; gap:10px;
+      display:flex; align-items:center; justify-content:flex-start; gap:10px;
+      min-height:100px; height:100%;
     }
     .feature-list .tick{width:16px; height:16px; border-radius:4px; border:1px solid #2a2a2e; background:#121214; display:grid;place-items:center; font-size:12px}
     .feature-list span{color:#e9e9e9}
@@ -166,10 +166,10 @@
     /* ===== Steps ===== */
     .steps{
       list-style:none; padding:0; margin:10px 0 0;
-      display:grid; gap:14px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+      display:grid; gap:20px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); grid-auto-rows:1fr;
     }
     .steps li{
-      position:relative; background:var(--card); border:1px solid var(--line); border-radius:16px; padding:14px;
+      position:relative; background:var(--card); border:1px solid var(--line); border-radius:16px; padding:14px; height:100%;
     }
     .steps .num{
       position:absolute; top:10px; right:10px; width:26px; height:26px; display:grid; place-items:center;
@@ -204,10 +204,6 @@
 
   <!-- NAV -->
   <header class="nav">
-    <a class="brand" href="#top" aria-label="Clutch">
-      <!-- the one and only logo (no banner) -->
-      <img src="./assets/clutch_logo.png" alt="Clutch logo">
-    </a>
     <nav class="nav-links">
       <a href="#why">Why</a>
       <a href="#features">Features</a>
@@ -284,6 +280,7 @@
         <li><span class="tick">✓</span><span>Immediate speech stop on interrupt (“Hey Jarvis” again)</span></li>
         <li><span class="tick">✓</span><span>Bomb & round timers (local, resilient)</span></li>
         <li><span class="tick">✓</span><span>Windows desktop UI (PyQt)</span></li>
+        <li><span class="tick">✓</span><span>MIT open-source license</span></li>
       </ul>
     </section>
 
@@ -389,6 +386,13 @@
     // Mouse spotlight + title glow
     const spot = document.querySelector('.spot');
     const title = document.querySelector('.glow-title');
+    const why = document.getElementById('why');
+    const toggleSpot = ()=>{
+      const bottom = why.offsetTop + why.offsetHeight;
+      spot.style.display = (window.scrollY >= bottom) ? 'block' : 'none';
+    };
+    toggleSpot();
+    window.addEventListener('scroll', toggleSpot, {passive:true});
     window.addEventListener('pointermove', (e)=>{
       const x = e.clientX, y = e.clientY;
       spot.style.setProperty('--mx', x+'px');
@@ -399,6 +403,19 @@
         title.classList.toggle('glow', inside);
       }
     }, {passive:true});
+
+    // Equalize box heights
+    const equalize = (sel)=>{
+      const els = document.querySelectorAll(sel);
+      let max=0;
+      els.forEach(el=>{max=Math.max(max, el.offsetHeight);});
+      els.forEach(el=> el.style.height = max+'px');
+    };
+    window.addEventListener('load', ()=>{
+      equalize('.cards .card');
+      equalize('.feature-list li');
+      equalize('.steps li');
+    });
 
     // Apply subtle wavy filter to hero + cards for a living UI feel
     const wavify = (els)=> els.forEach(el=> el.style.filter = 'url(#wavy)');


### PR DESCRIPTION
## Summary
- Remove top navbar logo and center navigation links
- Dim text colors slightly and increase vertical spacing for a calmer layout
- Even out card heights and expand features to a 3x3 grid with spotlight enabled only below the Why section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba3a9c76883329d17df46a8913291